### PR TITLE
Fix #24, Enforce standard style in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+dist: bionic
+sudo: required
+language:
+  - c
+compiler:
+  - gcc
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - cmake
+
+before_install:
+  - sudo apt-get install cppcheck
+  - cppcheck --version
+  # for clang-format 10
+  - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+  - sudo add-apt-repository 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic  main'
+  - sudo apt-get update
+  - sudo apt-get install clang-format-10
+  - clang-format-10 --version
+
+
+script:
+  # Get bundle (doesn't populate submodules, not needed for style enforcement)
+  - cd ..
+  - git clone https://github.com/nasa/cFS.git
+  - mv ci_lab cFS/apps
+  - cd cFS/apps/ci_lab
+  # Enforce formatting
+  - find . -name "*.[ch]" -exec clang-format-10 -i -style=file {} +
+  - git diff > style_differences.txt
+  - |
+    if [[ -s style_differences.txt ]]; then
+      echo "You must fix style differences before submitting a pull request"
+      echo ""
+      cat style_differences.txt
+      exit -1
+    fi


### PR DESCRIPTION
**Describe the contribution**
Fix #24 - CI enforcement of style

**Testing performed**
See CI results - no independent testing required

**Expected behavior changes**
Style enforced, CI will fail if new pull request does not meet expected style.

**System(s) tested on:**
 - CI, requires https://github.com/nasa/cFS/pull/38 to be merged to master to work

**Additional context**
None

**Contributor Info**
Jacob Hagement - NASA/GSFC