### PR TITLE
Fix #39, Clang-format-10 fails in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - cppcheck --version
   # for clang-format 10
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-  - sudo add-apt-repository 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic  main'
+  - sudo add-apt-repository 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-10 main'
   - sudo apt-get update
   - sudo apt-get install clang-format-10
   - clang-format-10 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
+os: linux
 dist: bionic
-sudo: required
-language:
-  - c
+language: c
 compiler:
   - gcc
 addons:


### PR DESCRIPTION
**Describe the contribution**
Fix #39 

**Testing performed**
Ran CI

**Expected behavior changes**
CI builds
No more warnings in config section of travis

**System(s) tested on**
CI - Ubuntu Bionic

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz NASA/GSFC