### PR TITLE
Fix #37, Offset the UDP base port per-CPU

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -154,7 +154,8 @@ void CI_LAB_delete_callback(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 void CI_LAB_TaskInit(void)
 {
-    int32 status;
+    int32  status;
+    uint16 DefaultListenPort;
 
     memset(&CI_LAB_Global, 0, sizeof(CI_LAB_Global));
 
@@ -176,7 +177,8 @@ void CI_LAB_TaskInit(void)
     else
     {
         OS_SocketAddrInit(&CI_LAB_Global.SocketAddress, OS_SocketDomain_INET);
-        OS_SocketAddrSetPort(&CI_LAB_Global.SocketAddress, cfgCI_LAB_PORT);
+        DefaultListenPort = CI_LAB_BASE_UDP_PORT + CFE_PSP_GetProcessorId() - 1;
+        OS_SocketAddrSetPort(&CI_LAB_Global.SocketAddress, DefaultListenPort);
 
         status = OS_SocketBind(CI_LAB_Global.SocketID, &CI_LAB_Global.SocketAddress);
 
@@ -188,6 +190,7 @@ void CI_LAB_TaskInit(void)
         else
         {
             CI_LAB_Global.SocketConnected = true;
+            CFE_ES_WriteToSysLog("CI_LAB listening on UDP port: %u\n", (unsigned int)DefaultListenPort);
         }
     }
 

--- a/fsw/src/ci_lab_app.h
+++ b/fsw/src/ci_lab_app.h
@@ -46,9 +46,9 @@
 
 /****************************************************************************/
 
-#define cfgCI_LAB_PORT    1234
-#define CI_LAB_MAX_INGEST 768
-#define CI_LAB_PIPE_DEPTH 32
+#define CI_LAB_BASE_UDP_PORT 1234
+#define CI_LAB_MAX_INGEST    768
+#define CI_LAB_PIPE_DEPTH    32
 
 /************************************************************************
 ** Type Definitions


### PR DESCRIPTION
**Describe the contribution**
Avoid port conflicts when having more than one CPU within the same mission load CI_LAB app.  Instead of binding to the port directly, add the CPU number as an offset.  Subtract 1 so that CPU1 remains at the same port (1234 by default) and cmdUtil is not affected.

NOTE: the "cpu number" can be overridden on the command line when using the pc-linux PSP, thereby also permitting the listen point to be tuned for each launch config, if necessary.

**Testing performed**
Build using default config, ensure no errors.
Run FSW and test sending commands with `cmdUtil` - confirm no impact when using defaults, still listens on port 1234 as before and can send commands.
Run FSW using `--cpuid 2` switch, confirm that listening port has changed, observing syslog trace:
`1980-012-14:03:20.25227 CI_LAB listening on UDP port: 1235`
Confirmed that `cmdUtil` still works to send commands if the `--port 1235` option is given.

**Expected behavior changes**
- No behavior changes in the default/example config when also running with all defaults.
- CI_LAB changes its listening port when either using a config with multiple CPUs or using the `--cpuid` option to override (in pc-linux at least).

**System(s) tested on**
 - Ubuntu 18.04 LTS, 64 bit

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
