### PR TITLE
Fix comment issues in recent ic-20200304 merge

### DIFF
--- a/fsw/src/ci_lab_msg.h
+++ b/fsw/src/ci_lab_msg.h
@@ -30,7 +30,7 @@
 #define _ci_lab_msg_h_
 
 /*
-** CI_LAB_Lab command codes
+** CI_LAB command codes
 */
 #define CI_LAB_NOOP_CC           0
 #define CI_LAB_RESET_COUNTERS_CC 1
@@ -57,7 +57,7 @@ typedef CI_LAB_NoArgsCmd_t CI_LAB_ResetCounters_t;
 
 /*************************************************************************/
 /*
-** Type definition (CI_LAB_Lab housekeeping)...
+** Type definition (CI_LAB housekeeping)...
 */
 typedef struct
 {


### PR DESCRIPTION
**Describe the contribution**
Minor fixup for comments in recent merge

The recent name fixes created two occurrences of `CI_LAB_Lab` inside commends which was not noticed during review.  Minor fix.

**Testing performed**
Sanity check only - Build and run, confirm no issues.

**Expected behavior changes**
None - fixes code comment issue only.

**System(s) tested on**
 - Ubuntu 18.04 LTS, 64 bit

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
