### PR TITLE
Integration Candidate 20200318

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -154,7 +154,8 @@ void CI_LAB_delete_callback(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 void CI_LAB_TaskInit(void)
 {
-    int32 status;
+    int32  status;
+    uint16 DefaultListenPort;
 
     memset(&CI_LAB_Global, 0, sizeof(CI_LAB_Global));
 
@@ -176,7 +177,8 @@ void CI_LAB_TaskInit(void)
     else
     {
         OS_SocketAddrInit(&CI_LAB_Global.SocketAddress, OS_SocketDomain_INET);
-        OS_SocketAddrSetPort(&CI_LAB_Global.SocketAddress, cfgCI_LAB_PORT);
+        DefaultListenPort = CI_LAB_BASE_UDP_PORT + CFE_PSP_GetProcessorId() - 1;
+        OS_SocketAddrSetPort(&CI_LAB_Global.SocketAddress, DefaultListenPort);
 
         status = OS_SocketBind(CI_LAB_Global.SocketID, &CI_LAB_Global.SocketAddress);
 
@@ -188,6 +190,7 @@ void CI_LAB_TaskInit(void)
         else
         {
             CI_LAB_Global.SocketConnected = true;
+            CFE_ES_WriteToSysLog("CI_LAB listening on UDP port: %u\n", (unsigned int)DefaultListenPort);
         }
     }
 

--- a/fsw/src/ci_lab_app.h
+++ b/fsw/src/ci_lab_app.h
@@ -46,9 +46,9 @@
 
 /****************************************************************************/
 
-#define cfgCI_LAB_PORT    1234
-#define CI_LAB_MAX_INGEST 768
-#define CI_LAB_PIPE_DEPTH 32
+#define CI_LAB_BASE_UDP_PORT 1234
+#define CI_LAB_MAX_INGEST    768
+#define CI_LAB_PIPE_DEPTH    32
 
 /************************************************************************
 ** Type Definitions


### PR DESCRIPTION
**Describe the contribution**
Fix #41 

**Testing performed**
See PR, 
Bundle testing in CI

**Expected behavior changes**
See PR, CI_LAB changes its listening port when either using a config with multiple CPUs or using the --cpuid option to override (in pc-linux at least).

**System(s) tested on**
CI Ubuntu: Bionic

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
Gerardo E. Cruz-Ortiz, NASA-GSFC