### PR TITLE
Fix #45, Opaque CFE_SB_MsgId_t values

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -225,7 +225,7 @@ void CI_LAB_ProcessCommandPacket(void)
     CFE_SB_MsgId_t MsgId;
     MsgId = CFE_SB_GetMsgId(CI_LAB_Global.MsgPtr);
 
-    switch (MsgId)
+    switch (CFE_SB_MsgIdToValue(MsgId))
     {
         case CI_LAB_CMD_MID:
             CI_LAB_ProcessGroundCommand();
@@ -238,7 +238,7 @@ void CI_LAB_ProcessCommandPacket(void)
         default:
             CI_LAB_Global.HkBuffer.HkTlm.Payload.CommandErrorCounter++;
             CFE_EVS_SendEvent(CI_LAB_COMMAND_ERR_EID, CFE_EVS_EventType_ERROR, "CI: invalid command packet,MID = 0x%x",
-                              MsgId);
+                              (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
     }
 
@@ -407,8 +407,9 @@ bool CI_LAB_VerifyCmdLength(CFE_SB_MsgPtr_t msg, uint16 ExpectedLength)
         uint16         CommandCode = CFE_SB_GetCmdCode(msg);
 
         CFE_EVS_SendEvent(CI_LAB_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "Invalid msg length: ID = 0x%X,  CC = %d, Len = %d, Expected = %d", MessageID, CommandCode,
-                          ActualLength, ExpectedLength);
+                          "Invalid msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
+                          (unsigned int)CFE_SB_MsgIdToValue(MessageID), (unsigned int)CommandCode,
+                          (unsigned int)ActualLength, (unsigned int)ExpectedLength);
         result = false;
         CI_LAB_Global.HkBuffer.HkTlm.Payload.CommandErrorCounter++;
     }


### PR DESCRIPTION
**Describe the contribution**
Apply the `CFE_SB_MsgIdToValue()` and `CFE_SB_ValueToMsgId()` routines where compatibility with an integer MsgId is necessary - syslog prints, events, compile-time MID `#define` values.

Fixes #45 

**Testing performed**
Unit test
Execute CFE and sanity-check normal operation - send commands to app using `cmdUtil` and confirm commands are processed normally.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 18.04 LTS, 64-bit

**Additional context**
In future versions of CFE SB the MsgId type might not be a simple integer, so this is one step in the direction of avoiding this assumption in apps.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.