### PR TITLE
Close #51, Add buildnumber and baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ ci_lab is a simple command uplink application that accepts CCSDS telecommand pac
 
 ## Version History
 
+### Development Build: 2.3.0+dev36
+
+- Add build name and build number to version reporting
+- See <https://github.com/nasa/ci_lab/pull/53>
+
 ### Development Build: 2.3.5
 
-- Replace references to `ccsds.h` types with the `cfe_sb.h`-provided type. 
-- See <https://github.com/nasa/ci_lab/pull/50> 
+- Replace references to `ccsds.h` types with the `cfe_sb.h`-provided type.
+- See <https://github.com/nasa/ci_lab/pull/50>
 
 ### Development Build: 2.3.4
 

--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -203,8 +203,8 @@ void CI_LAB_TaskInit(void)
 
     CFE_SB_InitMsg(&CI_LAB_Global.HkBuffer.HkTlm, CI_LAB_HK_TLM_MID, CI_LAB_HK_TLM_LNGTH, true);
 
-    CFE_EVS_SendEvent(CI_LAB_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI Lab Initialized.  Version %d.%d.%d.%d",
-                      CI_LAB_MAJOR_VERSION, CI_LAB_MINOR_VERSION, CI_LAB_REVISION, CI_LAB_MISSION_REV);
+    CFE_EVS_SendEvent(CI_LAB_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI Lab Initialized.%s",
+                      CI_LAB_VERSION_STRING);
 
 } /* End of CI_LAB_TaskInit() */
 

--- a/fsw/src/ci_lab_version.h
+++ b/fsw/src/ci_lab_version.h
@@ -18,23 +18,48 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: ci_lab_version.h
-**
-** Purpose:
-**  The CI Lab Application header file containing version number
-**
-** Notes:
-**
 *************************************************************************/
-#ifndef _ci_lab_version_h_
-#define _ci_lab_version_h_
 
-#define CI_LAB_MAJOR_VERSION 2
-#define CI_LAB_MINOR_VERSION 3
-#define CI_LAB_REVISION      5
-#define CI_LAB_MISSION_REV   0
+/*! @file ci_lab_version.h
+ * @brief Purpose:
+ *
+ *  The CI Lab App header file containing version information
+ *
+ */
 
-#endif /* _ci_lab_version_h_ */
+#ifndef CI_LAB_VERSION_H
+#define CI_LAB_VERSION_H
+
+/* Development Build Macro Definitions */
+
+#define CI_LAB_BUILD_NUMBER   36       /*!< Development Build: Number of commits since baseline */
+#define CI_LAB_BUILD_BASELINE "v2.3.0" /*!< Development Build: git tag that is the base for the current development */
+
+/* Version Macro Definitions */
+
+#define CI_LAB_MAJOR_VERSION 2 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define CI_LAB_MINOR_VERSION 3 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define CI_LAB_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define CI_LAB_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+
+#define CI_LAB_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
+#define CI_LAB_STR(x)        CI_LAB_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
+
+/*! @brief Development Build Version Number.
+ * @details Baseline git tag + Number of commits since baseline. @n
+ * See @ref cfsversions for format differences between development and release versions.
+ */
+#define CI_LAB_VERSION CI_LAB_BUILD_BASELINE "+dev" CI_LAB_STR(CI_LAB_BUILD_NUMBER)
+
+/*! @brief Development Build Version String.
+ * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
+ * official version. @n See @ref cfsversions for format differences between development and release versions.
+ */
+#define CI_LAB_VERSION_STRING                       \
+    " CI Lab App DEVELOPMENT BUILD " CI_LAB_VERSION \
+    ", Last Official Release: v2.3.0" /* For full support please use this version */
+
+#endif /* CI_LAB_VERSION_H */
 
 /************************/
 /*  End of File Comment */


### PR DESCRIPTION
**Describe the contribution**
Close #51 

**Testing performed**
Bundle test - https://github.com/astrogeco/cFS/runs/972139876

**Expected behavior changes**
Version reporting uses version string macro and reports development versions build number. Development version display shows up as
```
EVS Port1 42/1/CI_LAB_APP 3: CI Lab Initialized. CI Lab App DEVELOPMENT BUILD v2.3.0+dev36, Last Official Release: v2.3.0
```

**System(s) tested on**
Augmented [GCC Docker Image](https://github.com/docker-library/gcc/blob/36c1ff6d7b44428b35fa8b61787c76b225d8184a/10/Dockerfile)

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC