### PR TITLE
Fix #54, Update CI_Lab to use osal_id_t

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -63,7 +63,7 @@ typedef struct
     bool            SocketConnected;
     CFE_SB_PipeId_t CommandPipe;
     CFE_SB_MsgPtr_t MsgPtr;
-    uint32          SocketID;
+    osal_id_t       SocketID;
     OS_SockAddr_t   SocketAddress;
 
     CI_LAB_HkTlm_Buffer_t HkBuffer;


### PR DESCRIPTION
**Describe the contribution**
Update the SocketID field to be `osal_id_t` instead of `uint32`

Fixes #54 

**Testing performed**
Build and sanity test CFE

**Expected behavior changes**
None.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This makes it consistent with other modules

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
