### PR TITLE
Fix #59, Remove non-portable OS_PACK

### DIFF
--- a/fsw/src/ci_lab_msg.h
+++ b/fsw/src/ci_lab_msg.h
@@ -76,7 +76,7 @@ typedef struct
 {
     uint8                  TlmHeader[CFE_SB_TLM_HDR_SIZE];
     CI_LAB_HkTlm_Payload_t Payload;
-} OS_PACK CI_LAB_HkTlm_t;
+} CI_LAB_HkTlm_t;
 
 #define CI_LAB_HK_TLM_LNGTH sizeof(CI_LAB_HkTlm_t)
 


### PR DESCRIPTION
**Describe the contribution**
Fix #59 - removes OS_PACK (not portable)

**Testing performed**
Didn't confirm offsets, but checked size before and after and there was no change (36).  cFS-GroundSystem doesn't display the message, but passed unit tests and ran a few commands through the system.

**Expected behavior changes**
No impact, but removes undesirable pattern

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Will update other patterns to match #1009 in a separate commit/PR.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC