### PR TITLE
Fix #77, use cfe.h instead of individual headers

### DIFF
--- a/fsw/src/ci_lab_app.h
+++ b/fsw/src/ci_lab_app.h
@@ -32,11 +32,7 @@
 ** Required header files...
 */
 #include "common_types.h"
-#include "cfe_error.h"
-#include "cfe_evs.h"
-#include "cfe_sb.h"
-#include "cfe_es.h"
-#include "cfe_msg_api.h"
+#include "cfe.h"
 
 #include "osapi.h"
 


### PR DESCRIPTION
**Describe the contribution**
Use `cfe.h` in ci_lab rather than the individual component-specific headers.

The all-inclusive header should give everything needed, and be more future proof in case component names ever need to change.

Fixes #77 

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
No impact

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Needed for nasa/cfe#1203

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
