### PR TITLE
Fix #73, use zero copy API

### DIFF
--- a/fsw/src/ci_lab_events.h
+++ b/fsw/src/ci_lab_events.h
@@ -37,7 +37,9 @@
 #define CI_LAB_COMMANDNOP_INF_EID   5
 #define CI_LAB_COMMANDRST_INF_EID   6
 #define CI_LAB_INGEST_INF_EID       7
-#define CI_LAB_INGEST_ERR_EID       8
+#define CI_LAB_INGEST_LEN_ERR_EID   8
+#define CI_LAB_INGEST_ALLOC_ERR_EID 9
+#define CI_LAB_INGEST_SEND_ERR_EID  10
 #define CI_LAB_LEN_ERR_EID          16
 
 #endif /* _ci_lab_events_h_ */


### PR DESCRIPTION
**Describe the contribution**
Updates CI_LAB to obtain a buffer prior to calling `OS_SocketRecvFrom`, and then transmit that same buffer directly rather than copying it.

This demonstrates use of the Zero Copy API.

Fixes #73

**Testing performed**
Build CFE along with nasa/cfe#1257 and send various commands using "cmdUtil".  Confirm that commands were received correctly.

**Expected behavior changes**
Internal change only - No impact to external behavior.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Requires nasa/cfe#1257 as prerequisite

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
