### PR TITLE
Fixed typos in SECURITY.md and ci_lab_app.c

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ To report a vulnerability for the ci_lab subsystem please [submit an issue](http
 
 For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy) for additional information.
 
-In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropriate labels for each report. For security related reports, tag the issue with the "security" label.
 
 ## Testing
 

--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -80,7 +80,7 @@ int32 CI_LAB_ReportHousekeeping(const CFE_MSG_CommandHeader_t *data);
 /* Purpose: This is the Main task event loop for the Command Ingest Task      */
 /*            The task handles all interfaces to the data system through      */
 /*            the software bus. There is one pipeline into this task          */
-/*            The task is sceduled by input into this pipeline.               */
+/*            The task is scheduled by input into this pipeline.               */
 /*            It can receive Commands over this pipeline                      */
 /*            and acts accordingly to process them.                           */
 /*                                                                            */


### PR DESCRIPTION
**Describe the contribution**
Fixed a couple of minor typos in the _text_ of:
- SECURITY.md
  
...and in the _comments_ of:
- fsw/src/ci_lab_app.c
  
**Testing performed**
None (non-executable code).

**Expected behavior changes**
None (minor Markdown doc and comments changes).

**System(s) tested on**
n/a

**Additional context**
n/a

**Code contributions**
n/a