### PR TITLE
Fix #91, apply CFE_SB_ValueToMsgId where required

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -150,8 +150,8 @@ void CI_LAB_TaskInit(void)
                      CFE_EVS_EventFilter_BINARY);
 
     CFE_SB_CreatePipe(&CI_LAB_Global.CommandPipe, CI_LAB_PIPE_DEPTH, "CI_LAB_CMD_PIPE");
-    CFE_SB_Subscribe(CI_LAB_CMD_MID, CI_LAB_Global.CommandPipe);
-    CFE_SB_Subscribe(CI_LAB_SEND_HK_MID, CI_LAB_Global.CommandPipe);
+    CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CI_LAB_CMD_MID), CI_LAB_Global.CommandPipe);
+    CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CI_LAB_SEND_HK_MID), CI_LAB_Global.CommandPipe);
 
     status = OS_SocketOpen(&CI_LAB_Global.SocketID, OS_SocketDomain_INET, OS_SocketType_DATAGRAM);
     if (status != OS_SUCCESS)
@@ -186,7 +186,8 @@ void CI_LAB_TaskInit(void)
     */
     OS_TaskInstallDeleteHandler(&CI_LAB_delete_callback);
 
-    CFE_MSG_Init(&CI_LAB_Global.HkTlm.TlmHeader.Msg, CI_LAB_HK_TLM_MID, sizeof(CI_LAB_Global.HkTlm));
+    CFE_MSG_Init(&CI_LAB_Global.HkTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(CI_LAB_HK_TLM_MID),
+                 sizeof(CI_LAB_Global.HkTlm));
 
     CFE_EVS_SendEvent(CI_LAB_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI Lab Initialized.%s",
                       CI_LAB_VERSION_STRING);


### PR DESCRIPTION
**Describe the contribution**
Whenever an integer value is used as a CFE_SB_MsgId_t, it should go through the explicit conversion using the supplied inline
function.

Fixes #91

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
Allows CI_LAB to be built when CFE_SB_MsgId_t is an opaque/non-integer type.
None with default config (where CFE_SB_MsgId_t is an integer type).

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.