### PR TITLE
Fix #94, Use CFE_MSG_PTR conversion macro

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -186,7 +186,7 @@ void CI_LAB_TaskInit(void)
     */
     OS_TaskInstallDeleteHandler(&CI_LAB_delete_callback);
 
-    CFE_MSG_Init(&CI_LAB_Global.HkTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(CI_LAB_HK_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CI_LAB_Global.HkTlm.TelemetryHeader), CFE_SB_ValueToMsgId(CI_LAB_HK_TLM_MID),
                  sizeof(CI_LAB_Global.HkTlm));
 
     CFE_EVS_SendEvent(CI_LAB_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI Lab Initialized.%s",
@@ -314,8 +314,8 @@ int32 CI_LAB_ResetCounters(const CI_LAB_ResetCountersCmd_t *data)
 int32 CI_LAB_ReportHousekeeping(const CFE_MSG_CommandHeader_t *data)
 {
     CI_LAB_Global.HkTlm.Payload.SocketConnected = CI_LAB_Global.SocketConnected;
-    CFE_SB_TimeStampMsg(&CI_LAB_Global.HkTlm.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&CI_LAB_Global.HkTlm.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CI_LAB_Global.HkTlm.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CI_LAB_Global.HkTlm.TelemetryHeader), true);
     return CFE_SUCCESS;
 
 } /* End of CI_LAB_ReportHousekeeping() */

--- a/fsw/src/ci_lab_msg.h
+++ b/fsw/src/ci_lab_msg.h
@@ -74,7 +74,7 @@ typedef struct
 
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader;
+    CFE_MSG_TelemetryHeader_t TelemetryHeader;
     CI_LAB_HkTlm_Payload_t    Payload;
 } CI_LAB_HkTlm_t;
 


### PR DESCRIPTION
**Describe the contribution**
Updates conversions to CFE_Message_t to use the MSG macro
This also uses consistent naming - TelemetryHeader rather than TlmHeader

Fixes #94

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
Depends on nasa/cfe#1966

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
