### PR TITLE
Fix #99, Reuse CodeQL, Static Analysis, and Format Check

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -2,54 +2,12 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches:
-      - main
   pull_request:
-
-env:
-  SIMULATION: native
-  ENABLE_UNIT_TESTS: true
-  OMIT_DEPRECATED: true
-  BUILDTYPE: release
-
+  
 jobs:
-
-  CodeQL-Build:
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
-      - name: Checkout bundle
-        uses: actions/checkout@v2
-        with:
-          repository: nasa/cFS
-          submodules: true
-
-      - name: Checkout submodule
-        uses: actions/checkout@v2
-        with:
-          path: apps/ci_lab
-
-      - name: Check versions
-        run: git submodule
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
-        with:
-         languages: c
-         queries: +security-extended, security-and-quality
-
-      # Setup the build system
-      - name: Set up for build
-        run: |
-          cp ./cfe/cmake/Makefile.sample Makefile
-          cp -r ./cfe/cmake/sample_defs sample_defs
-          make prep
-
-      # Build the code
-      - name: Build
-        run: make ci_lab
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+  codeql:
+    name: CodeQL Analysis
+    uses: nasa/cFS/.github/workflows/codeql-build.yml@main
+    with: 
+      make-prep: 'make prep'
+      make: 'make ci_lab'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,53 +1,11 @@
 name: Format Check
 
-# Run on main push and pull requests
+# Run on all push and pull requests
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
-
-  static-analysis:
+  format-check:
     name: Run format check
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-
-      - name: Install format checker
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/bionic/   llvm-toolchain-bionic-10 main'
-          sudo apt-get update && sudo apt-get install clang-format-10
-
-      - name: Checkout bundle
-        uses: actions/checkout@v2
-        with:
-          repository: nasa/cFS
-
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          path: repo
-
-      - name: Generate format differences
-        run: |
-          cd repo
-          find . -name "*.[ch]" -exec clang-format-10 -i -style=file {} +
-          git diff > $GITHUB_WORKSPACE/style_differences.txt
-
-      - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: style_differences
-          path: style_differences.txt
-
-      - name: Error on differences
-        run: |
-          if [[ -s style_differences.txt ]];
-          then
-            cat style_differences.txt
-            exit -1
-          fi
+    uses: nasa/cFS/.github/workflows/format-check.yml@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,40 +1,10 @@
-name: Static Analysis
+name: Reuse Static Analysis
 
-# Run on main push and pull requests
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
-
   static-analysis:
-    name: Run cppcheck
-    runs-on: ubuntu-18.04
-    timeout-minutes: 15
-
-    steps:
-
-      - name: Install cppcheck
-        run: sudo apt-get install cppcheck -y
-
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Run general cppcheck
-        run: cppcheck --force --inline-suppr --quiet . 2> cppcheck_err.txt
-
-      - name: Archive Static Analysis Artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: cppcheck-err
-          path: ./cppcheck_err.txt
-
-      - name: Check for errors
-        run: |
-          if [[ -s cppcheck_err.txt ]];
-          then
-            cat cppcheck_err.txt
-            exit -1
-          fi
+    name: Static Analysis
+    uses: nasa/cFS/.github/workflows/static-analysis.yml@main


### PR DESCRIPTION
**Describe the contribution**
Fixes #99 

**Testing performed**
ci_lab CodeQL Reuse: https://github.com/ArielSAdamsNASA/ci_lab/actions/runs/1391936340
ci_lab Format Check Reuse: https://github.com/ArielSAdamsNASA/ci_lab/actions/runs/1391958598
ci_lab Static Analyis Reuse: https://github.com/ArielSAdamsNASA/ci_lab/actions/runs/1391960515

**Expected behavior changes**
PSP will reuse CodeQL, Static Analysis, and Format Checker that are held in cFS. These workflows will not work until nasa/cFS#386 is merged.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal
