### PR TITLE
Fix #115, Remove unnecessary parentheses around return values.

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -424,6 +424,6 @@ bool CI_LAB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
         CI_LAB_Global.HkTlm.Payload.CommandErrorCounter++;
     }
 
-    return (result);
+    return result;
 
 } /* End of CI_LAB_VerifyCmdLength() */


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #115 
Removes parentheses in return statements in ci_lab that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 