### PR TITLE
Fix #117, Remove 'return;' from last line of void functions.

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -216,9 +216,6 @@ void CI_LAB_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
     }
-
-    return;
-
 } /* End CI_LAB_ProcessCommandPacket */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
@@ -254,9 +251,6 @@ void CI_LAB_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr)
         default:
             break;
     }
-
-    return;
-
 } /* End of CI_LAB_ProcessGroundCommand() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
@@ -325,9 +319,6 @@ void CI_LAB_ResetCounters_Internal(void)
     /* Status of packets ingested by CI task */
     CI_LAB_Global.HkTlm.Payload.IngestPackets = 0;
     CI_LAB_Global.HkTlm.Payload.IngestErrors  = 0;
-
-    return;
-
 } /* End of CI_LAB_ResetCounters() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
@@ -389,9 +380,6 @@ void CI_LAB_ReadUpLink(void)
             break; /* no (more) messages */
         }
     }
-
-    return;
-
 } /* End of CI_LAB_ReadUpLink() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #117
Removes all cases of redundant "return;" statements on the last line of void functions.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 