### PR TITLE
Fix #125, Standardize CI_LAB function names

### DIFF
--- a/config/default_ci_lab_fcncodes.h
+++ b/config/default_ci_lab_fcncodes.h
@@ -35,7 +35,12 @@
 /*
 ** CI_LAB command codes
 */
-#define CI_LAB_NOOP_CC           0
-#define CI_LAB_RESET_COUNTERS_CC 1
+#define CI_LAB_NOOP_CC                 0
+#define CI_LAB_RESET_COUNTERS_CC       1
+#define CI_LAB_MODIFY_PDU_FILESIZE_CC  2
+#define CI_LAB_CORRUPT_PDU_CHECKSUM_CC 3
+#define CI_LAB_DROP_PDUS_CC            4
+#define CI_LAB_CAPTURE_PDUS_CC         5
+#define CI_LAB_STOP_PDU_CAPTURE_CC     6
 
 #endif

--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -46,7 +46,7 @@ CI_LAB_GlobalData_t CI_LAB_Global;
 /*            and acts accordingly to process them.                           */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *  * *  * * * * **/
-void CI_Lab_AppMain(void)
+void CI_LAB_AppMain(void)
 {
     int32            status;
     uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;

--- a/fsw/src/ci_lab_app.h
+++ b/fsw/src/ci_lab_app.h
@@ -66,7 +66,7 @@ typedef struct
 ** Note: Except for the entry point (CI_LAB_AppMain), these
 **       functions are not called from any other source module.
 */
-void CI_Lab_AppMain(void);
+void CI_LAB_AppMain(void);
 void CI_LAB_TaskInit(void);
 void CI_LAB_ResetCounters_Internal(void);
 void CI_LAB_ReadUpLink(void);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #125
  - Standardize naming of CI_LAB functions to match predominant cFS style.
  - Updates the list of command codes in `ci_lab_msg.h` in order for CHeaderParser.py to correctly generate the full list of commands in the `CI_LAB_CMD` binary file.

Also requires a change to the [cfe startup script](https://github.com/nasa/cFE/pull/2168)
A few files in the [Ground System](https://github.com/nasa/cFS-GroundSystem/pull/230) should also be updated to match the predominant convention.

**Testing performed**
Only GitHub CI workflow actions.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 