### PR TITLE
Fix #127, Rename CommandCode variable to FcnCode

### DIFF
--- a/fsw/src/ci_lab_dispatch.c
+++ b/fsw/src/ci_lab_dispatch.c
@@ -68,12 +68,12 @@ bool CI_LAB_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
 
 void CI_LAB_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr)
 {
-    CFE_MSG_FcnCode_t CommandCode = 0;
+    CFE_MSG_FcnCode_t FcnCode = 0;
 
-    CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
+    CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &FcnCode);
 
     /* Process "known" CI task ground commands */
-    switch (CommandCode)
+    switch (FcnCode)
     {
         case CI_LAB_NOOP_CC:
             if (CI_LAB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CI_LAB_NoopCmd_t)))


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #127 
  - Rename the `CommandCode` variable in `CI_LAB_ProcessGroundCommand()` to `FcnCode` to better align with the cFE API.

**Testing performed**
Standard cFS bundle tests all passed.
Build/run cFS and test NOOP and other commands with the GroundSystem tool. All working fine.

**Expected behavior changes**
No impact on behavior.
Improves code clarity and consistency in the lab apps.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
cFE v7.0.0-rc4+dev197, OSAL v6.0.0-rc4+dev143, PSP v1.6.0-rc4+d
Sample App v1.3.0-rc4+dev35
CI Lab App v2.5.0-rc4+dev39
TO Lab v2.5.0-rc4+dev31

**Contributor Info**
Avi Weiss @thnkslprpt