### PR TITLE
Fix #129, Apply consistent Event ID names to common events

### DIFF
--- a/fsw/inc/ci_lab_eventids.h
+++ b/fsw/inc/ci_lab_eventids.h
@@ -26,14 +26,14 @@
 #define CI_LAB_RESERVED_EID         0
 #define CI_LAB_SOCKETCREATE_ERR_EID 1
 #define CI_LAB_SOCKETBIND_ERR_EID   2
-#define CI_LAB_STARTUP_INF_EID      3
-#define CI_LAB_COMMAND_ERR_EID      4
-#define CI_LAB_COMMANDNOP_INF_EID   5
-#define CI_LAB_COMMANDRST_INF_EID   6
+#define CI_LAB_INIT_INF_EID         3
+#define CI_LAB_MID_ERR_EID          4
+#define CI_LAB_NOOP_INF_EID         5
+#define CI_LAB_RESET_INF_EID        6
 #define CI_LAB_INGEST_INF_EID       7
 #define CI_LAB_INGEST_LEN_ERR_EID   8
 #define CI_LAB_INGEST_ALLOC_ERR_EID 9
 #define CI_LAB_INGEST_SEND_ERR_EID  10
-#define CI_LAB_LEN_ERR_EID          16
+#define CI_LAB_CMD_LEN_ERR_EID      16
 
 #endif

--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -148,7 +148,7 @@ void CI_LAB_TaskInit(void)
     CFE_MSG_Init(CFE_MSG_PTR(CI_LAB_Global.HkTlm.TelemetryHeader), CFE_SB_ValueToMsgId(CI_LAB_HK_TLM_MID),
                  sizeof(CI_LAB_Global.HkTlm));
 
-    CFE_EVS_SendEvent(CI_LAB_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI Lab Initialized.%s",
+    CFE_EVS_SendEvent(CI_LAB_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "CI Lab Initialized.%s",
                       CI_LAB_VERSION_STRING);
 }
 

--- a/fsw/src/ci_lab_cmds.c
+++ b/fsw/src/ci_lab_cmds.c
@@ -39,7 +39,7 @@ CFE_Status_t CI_LAB_NoopCmd(const CI_LAB_NoopCmd_t *cmd)
     /* Does everything the name implies */
     CI_LAB_Global.HkTlm.Payload.CommandCounter++;
 
-    CFE_EVS_SendEvent(CI_LAB_COMMANDNOP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI: NOOP command");
+    CFE_EVS_SendEvent(CI_LAB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI: NOOP command");
 
     return CFE_SUCCESS;
 }
@@ -52,7 +52,7 @@ CFE_Status_t CI_LAB_NoopCmd(const CI_LAB_NoopCmd_t *cmd)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 CFE_Status_t CI_LAB_ResetCountersCmd(const CI_LAB_ResetCountersCmd_t *cmd)
 {
-    CFE_EVS_SendEvent(CI_LAB_COMMANDRST_INF_EID, CFE_EVS_EventType_INFORMATION, "CI: RESET command");
+    CFE_EVS_SendEvent(CI_LAB_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "CI: RESET command");
     CI_LAB_ResetCounters_Internal();
     return CFE_SUCCESS;
 }

--- a/fsw/src/ci_lab_dispatch.c
+++ b/fsw/src/ci_lab_dispatch.c
@@ -49,7 +49,7 @@ bool CI_LAB_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
         CFE_MSG_GetMsgId(MsgPtr, &MsgId);
         CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
 
-        CFE_EVS_SendEvent(CI_LAB_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CI_LAB_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
                           (unsigned int)ExpectedLength);
@@ -124,7 +124,7 @@ void CI_LAB_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
 
         default:
             CI_LAB_Global.HkTlm.Payload.CommandErrorCounter++;
-            CFE_EVS_SendEvent(CI_LAB_COMMAND_ERR_EID, CFE_EVS_EventType_ERROR, "CI: invalid command packet,MID = 0x%x",
+            CFE_EVS_SendEvent(CI_LAB_MID_ERR_EID, CFE_EVS_EventType_ERROR, "CI: invalid command packet,MID = 0x%x",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
     }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #129
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt