### PR TITLE
Fix #96, Check returns from CFE calls during init

### DIFF
--- a/fsw/inc/ci_lab_eventids.h
+++ b/fsw/inc/ci_lab_eventids.h
@@ -23,17 +23,20 @@
 #ifndef CI_LAB_EVENTIDS_H
 #define CI_LAB_EVENTIDS_H
 
-#define CI_LAB_RESERVED_EID         0
-#define CI_LAB_SOCKETCREATE_ERR_EID 1
-#define CI_LAB_SOCKETBIND_ERR_EID   2
-#define CI_LAB_INIT_INF_EID         3
-#define CI_LAB_MID_ERR_EID          4
-#define CI_LAB_NOOP_INF_EID         5
-#define CI_LAB_RESET_INF_EID        6
-#define CI_LAB_INGEST_INF_EID       7
-#define CI_LAB_INGEST_LEN_ERR_EID   8
-#define CI_LAB_INGEST_ALLOC_ERR_EID 9
-#define CI_LAB_INGEST_SEND_ERR_EID  10
-#define CI_LAB_CMD_LEN_ERR_EID      16
+#define CI_LAB_RESERVED_EID             0
+#define CI_LAB_SOCKETCREATE_ERR_EID     1
+#define CI_LAB_SOCKETBIND_ERR_EID       2
+#define CI_LAB_INIT_INF_EID             3
+#define CI_LAB_MID_ERR_EID              4
+#define CI_LAB_NOOP_INF_EID             5
+#define CI_LAB_RESET_INF_EID            6
+#define CI_LAB_INGEST_INF_EID           7
+#define CI_LAB_INGEST_LEN_ERR_EID       8
+#define CI_LAB_INGEST_ALLOC_ERR_EID     9
+#define CI_LAB_INGEST_SEND_ERR_EID      10
+#define CI_LAB_CR_PIPE_ERR_EID          11
+#define CI_LAB_SB_SUBSCRIBE_CMD_ERR_EID 12
+#define CI_LAB_SB_SUBSCRIBE_HK_ERR_EID  13
+#define CI_LAB_CMD_LEN_ERR_EID          16
 
 #endif


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #96 
  - Returns from `CFE_EVS_Register()`, `CFE_SB_CreatePipe()`,  and `CFE_SB_Subscribe()` during CI_LAB initialization sequence that are `!= CFE_SUCCESS` will now generate an EVS event reporting the error.
  - Also added new Event IDs for these error events.

**Testing performed**
Build + Run cFS locally to confirm CI_LAB still running fine with these changes.
![Screenshot 2022-11-08 11 13 53](https://user-images.githubusercontent.com/9024662/200450955-4c9f0885-f607-4936-a477-ed7826f41213.png)
Also ran with inverse for each event (checking if `status == CFE_SUCCESS`) to confirm structure and format of events is fine - they are shown here:
![Screenshot 2023-03-21 08 53 55](https://user-images.githubusercontent.com/9024662/226484963-852ebcc2-9b19-4d39-819e-d23ddf827ff0.png)

**Expected behavior changes**
Program logic not changed, but new events reports will now be generated for failures generated by these CFE calls.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch cFS bundle.

**Contributor Info**
Avi @thnkslprpt