### PR TITLE
Fix #138, Convert `int32` return codes and variables to `CFE_Status_t`

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -3,11 +3,11 @@ name: "CodeQL Analysis"
 on:
   push:
   pull_request:
-  
+
 jobs:
   codeql:
     name: CodeQL Analysis
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
-    with: 
+    with:
       component-path: apps/ci_lab
       make: 'make -C build/native/default_cpu1/apps/ci_lab'

--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -48,7 +48,7 @@ CI_LAB_GlobalData_t CI_LAB_Global;
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *  * *  * * * * **/
 void CI_Lab_AppMain(void)
 {
-    int32            status;
+    CFE_Status_t     status;
     uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;
     CFE_SB_Buffer_t *SBBufPtr;
 
@@ -177,9 +177,9 @@ void CI_LAB_ResetCounters_Internal(void)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
 void CI_LAB_ReadUpLink(void)
 {
-    int    i;
-    int32  status;
-    uint8 *bytes;
+    int          i;
+    CFE_Status_t status;
+    uint8 *      bytes;
 
     for (i = 0; i <= 10; i++)
     {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #138
  - `int32` return codes converted over to `CFE_Status_t`
  - a couple of `int32` `status`/`return` variables holding cFE return codes converted to `CFE_Status_t`

**Testing performed**
GitHub CI actions all passing successfully.
Local testing with full cFS suite passing all tests and showing not change to coverage.

**Expected behavior changes**
No change to behavior.
`CFE_Status_t` is more expressive and improves consistency with cFE/cFS.

**Contributor Info**
Avi Weiss @thnkslprpt