### PR TITLE
Fix #140, Move function prototypes to header file

### DIFF
--- a/config/default_ci_lab_msgdefs.h
+++ b/config/default_ci_lab_msgdefs.h
@@ -42,7 +42,6 @@ typedef struct
     uint32 IngestPackets;
     uint32 IngestErrors;
     uint32 Spare2;
-
 } CI_LAB_HkTlm_Payload_t;
 
 #endif

--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -31,7 +31,7 @@
 #include "ci_lab_version.h"
 
 /*
-** CI global data...
+** CI Global Data
 */
 CI_LAB_GlobalData_t CI_LAB_Global;
 

--- a/fsw/src/ci_lab_app.h
+++ b/fsw/src/ci_lab_app.h
@@ -36,11 +36,15 @@
 #include "ci_lab_dispatch.h"
 #include "ci_lab_cmds.h"
 
+#include "ci_lab_msg.h"
+
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
 
-/****************************************************************************/
+/************************************************************************
+ * Macro Definitions
+ ************************************************************************/
 
 /************************************************************************
 ** Type Definitions
@@ -73,5 +77,18 @@ void CI_LAB_ReadUpLink(void);
 
 /* Global State Object */
 extern CI_LAB_GlobalData_t CI_LAB_Global;
+
+/*
+ * Individual message handler function prototypes
+ *
+ * Per the recommended code pattern, these should accept a const pointer
+ * to a structure type which matches the message, and return an int32
+ * where CFE_SUCCESS (0) indicates successful handling of the message.
+ */
+int32 CI_LAB_Noop(const CI_LAB_NoopCmd_t *data);
+int32 CI_LAB_ResetCounters(const CI_LAB_ResetCountersCmd_t *data);
+
+/* Housekeeping message handler */
+int32 CI_LAB_ReportHousekeeping(const CFE_MSG_CommandHeader_t *data);
 
 #endif


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #140
  - Moves the function prototypes that were in `ci_lab_app.c` over to the header file

**Testing performed**
GitHub CI actions all passing successfully.
Local testing with full cFS suite confirms app performance unaffected.

**Expected behavior changes**
No change to behavior.
Makes the file content more consistent with the rest of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt