### PR TITLE
Fix #149, add decode hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(APP_SRC_FILES
     fsw/src/ci_lab_app.c
     fsw/src/ci_lab_cmds.c
     fsw/src/ci_lab_dispatch.c
+    fsw/src/ci_lab_passthru_decode.c
 )
 
 # Create the app module

--- a/fsw/src/ci_lab_app.h
+++ b/fsw/src/ci_lab_app.h
@@ -59,7 +59,8 @@ typedef struct
 
     CI_LAB_HkTlm_t HkTlm;
 
-    CFE_SB_Buffer_t *NextIngestBufPtr;
+    void * NetBufPtr;
+    size_t NetBufSize;
 
 } CI_LAB_GlobalData_t;
 

--- a/fsw/src/ci_lab_decode.h
+++ b/fsw/src/ci_lab_decode.h
@@ -1,0 +1,35 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *   This is the dispatch hdr file for the Command Ingest lab application.
+ */
+#ifndef CI_LAB_DECODE_H
+#define CI_LAB_DECODE_H
+
+/*
+** Required header files...
+*/
+#include "common_types.h"
+#include "cfe_sb_api_typedefs.h"
+
+CFE_Status_t CI_LAB_GetInputBuffer(void **BufferOut, size_t *SizeOut);
+CFE_Status_t CI_LAB_DecodeInputMessage(void *SourceBuffer, size_t SourceSize, CFE_SB_Buffer_t **DestBufferOut);
+
+#endif

--- a/fsw/src/ci_lab_passthru_decode.c
+++ b/fsw/src/ci_lab_passthru_decode.c
@@ -1,0 +1,114 @@
+/************************************************************************
+ * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ *
+ * Copyright (c) 2020 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * \file
+ *   This file contains the source code for the Command Ingest task.
+ */
+
+/*
+**   Include Files:
+*/
+#include "cfe.h"
+
+#include "ci_lab_app.h"
+#include "ci_lab_perfids.h"
+#include "ci_lab_msgids.h"
+#include "ci_lab_decode.h"
+
+/*
+ * ---------------------------------------
+ * In a "passthrough" configuration - the data from the network
+ * is expected to be a direct instance of the CFE_MSG_Message_t base,
+ * and thus something can be sent directly to SB.
+ *
+ * Instead of using an intermediate buffer, just get a buffer from
+ * SB and put it directly in there.  This reduces copying.
+ * ---------------------------------------
+ */
+CFE_Status_t CI_LAB_GetInputBuffer(void **BufferOut, size_t *SizeOut)
+{
+    CFE_SB_Buffer_t *IngestBuffer;
+    const size_t     IngestSize = CI_LAB_MAX_INGEST;
+
+    IngestBuffer = CFE_SB_AllocateMessageBuffer(IngestSize);
+    if (IngestBuffer == NULL)
+    {
+        *BufferOut = NULL;
+        *SizeOut   = 0;
+
+        CFE_EVS_SendEvent(CI_LAB_INGEST_ALLOC_ERR_EID, CFE_EVS_EventType_ERROR, "CI_LAB: buffer allocation failed\n");
+
+        return CFE_SB_BUF_ALOC_ERR;
+    }
+
+    *BufferOut = IngestBuffer;
+    *SizeOut   = IngestSize;
+
+    return CFE_SUCCESS;
+}
+
+/*
+ * ---------------------------------------
+ * In a "passthrough" configuration - the data from the network
+ * is expected to be a direct instance of the CFE_MSG_Message_t base,
+ * and thus something can be sent directly to SB.
+ *
+ * This just does a simple sanity check on the message size.  But
+ * otherwise, the source buffer is used directly as the output buffer.
+ * ---------------------------------------
+ */
+CFE_Status_t CI_LAB_DecodeInputMessage(void *SourceBuffer, size_t SourceSize, CFE_SB_Buffer_t **DestBufferOut)
+{
+    CFE_SB_Buffer_t *MsgBufPtr;
+    CFE_MSG_Size_t   MsgSize;
+    CFE_Status_t     Status;
+
+    if (SourceSize < sizeof(CFE_MSG_CommandHeader_t))
+    {
+        MsgBufPtr = NULL;
+        Status    = CFE_STATUS_WRONG_MSG_LENGTH;
+
+        CFE_EVS_SendEvent(CI_LAB_INGEST_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "CI: cmd dropped, bad packet length=%lu\n", (unsigned long)SourceSize);
+    }
+    else
+    {
+        MsgBufPtr = SourceBuffer;
+
+        /* Check the size from within the header itself, compare against network buffer size */
+        CFE_MSG_GetSize(&MsgBufPtr->Msg, &MsgSize);
+
+        if (MsgSize > SourceSize)
+        {
+            Status = CFE_STATUS_WRONG_MSG_LENGTH;
+
+            CFE_EVS_SendEvent(CI_LAB_INGEST_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "CI: cmd dropped - length mismatch, %lu (hdr) / %lu (packet)\n", (unsigned long)MsgSize,
+                              (unsigned long)SourceSize);
+        }
+        else
+        {
+            Status = CFE_SUCCESS;
+        }
+    }
+
+    *DestBufferOut = MsgBufPtr;
+
+    return Status;
+}


### PR DESCRIPTION
**Describe the contribution**
Add an intermediate step during ingest to allow the buffer to be decoded prior to sending to SB.  Initial implementation is just a pass-through, thus matching existing behavior.

Fixes #149

**Testing performed**
Build and run all tests, sanity check

**Expected behavior changes**
No current behavior change, but adds a hook/place for future behavior change

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
