### PR TITLE
Fix #52, Add version information to NOOP event

### DIFF
--- a/fsw/src/ci_lab_cmds.c
+++ b/fsw/src/ci_lab_cmds.c
@@ -27,6 +27,7 @@
 
 #include "ci_lab_app.h"
 #include "ci_lab_cmds.h"
+#include "ci_lab_version.h"
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                             */
@@ -39,7 +40,8 @@ CFE_Status_t CI_LAB_NoopCmd(const CI_LAB_NoopCmd_t *cmd)
     /* Does everything the name implies */
     CI_LAB_Global.HkTlm.Payload.CommandCounter++;
 
-    CFE_EVS_SendEvent(CI_LAB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI: NOOP command");
+    CFE_EVS_SendEvent(CI_LAB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "CI: NOOP command. Version %d.%d.%d.%d",
+                      CI_LAB_MAJOR_VERSION, CI_LAB_MINOR_VERSION, CI_LAB_REVISION, CI_LAB_MISSION_REV);
 
     return CFE_SUCCESS;
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #52 
  - Version information added in to NOOP event.
  - Replaces https://github.com/nasa/ci_lab/pull/131 which was closed by mistake during merge conflict resolution

**Testing performed**
Run/Build and confirmed NOOP command event reporting as expected.
![Screenshot 2022-10-22 21 00 58](https://user-images.githubusercontent.com/9024662/197336158-b507480a-0cc2-4a51-b8c1-6b1813c0ede8.png)

**Expected behavior changes**
Adds version information to NOOP command to align with the other cFS components/apps.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)

**Contributor Info**
Avi Weiss @thnkslprpt