### PR TITLE
Fix #164, define msgids via topicids

### DIFF
--- a/arch_build.cmake
+++ b/arch_build.cmake
@@ -20,8 +20,14 @@ set(CI_LAB_PLATFORM_CONFIG_FILE_LIST
 # This makes them individually overridable by the missions, without modifying
 # the distribution default copies
 foreach(CI_LAB_CFGFILE ${CI_LAB_PLATFORM_CONFIG_FILE_LIST})
+  get_filename_component(CFGKEY "${CI_LAB_CFGFILE}" NAME_WE)
+  if (DEFINED CI_LAB_CFGFILE_SRC_${CFGKEY})
+    set(DEFAULT_SOURCE GENERATED_FILE "${CI_LAB_CFGFILE_SRC_${CFGKEY}}")
+  else()
+    set(DEFAULT_SOURCE FALLBACK_FILE "${CMAKE_CURRENT_LIST_DIR}/config/default_${CI_LAB_CFGFILE}")
+  endif()
   generate_config_includefile(
     FILE_NAME           "${CI_LAB_CFGFILE}"
-    FALLBACK_FILE       "${CMAKE_CURRENT_LIST_DIR}/config/default_${CI_LAB_CFGFILE}"
+    ${DEFAULT_SOURCE}
   )
 endforeach()

--- a/config/default_ci_lab_topicids.h
+++ b/config/default_ci_lab_topicids.h
@@ -18,16 +18,13 @@
 
 /**
  * @file
- *   CI_LAB Application Message IDs
+ *   CI_LAB Application Topic IDs
  */
-#ifndef CI_LAB_MSGIDS_H
-#define CI_LAB_MSGIDS_H
+#ifndef CI_LAB_TOPICIDS_H
+#define CI_LAB_TOPICIDS_H
 
-#include "cfe_core_api_base_msgids.h"
-#include "ci_lab_topicids.h"
-
-#define CI_LAB_CMD_MID     CFE_PLATFORM_CMD_TOPICID_TO_MIDV(CI_LAB_CMD_TOPICID)
-#define CI_LAB_SEND_HK_MID CFE_PLATFORM_CMD_TOPICID_TO_MIDV(CI_LAB_SEND_HK_TOPICID)
-#define CI_LAB_HK_TLM_MID  CFE_PLATFORM_TLM_TOPICID_TO_MIDV(CI_LAB_HK_TLM_TOPICID)
+#define CI_LAB_CMD_TOPICID     0x84
+#define CI_LAB_SEND_HK_TOPICID 0x85
+#define CI_LAB_HK_TLM_TOPICID  0x84
 
 #endif

--- a/mission_build.cmake
+++ b/mission_build.cmake
@@ -17,6 +17,7 @@ set(CI_LAB_MISSION_CONFIG_FILE_LIST
   ci_lab_msgdefs.h
   ci_lab_msg.h
   ci_lab_msgstruct.h
+  ci_lab_topicids.h
 )
 
 if (CFE_EDS_ENABLED_BUILD)


### PR DESCRIPTION
**Describe the contribution**
The MsgID value is a conversion from TopicID

Fixes #164

**Testing performed**
Build and run tests

**Expected behavior changes**
None, topic IDs were chosen such that the resulting MsgIDs are the same when using default config

**System(s) tested on**
Debian

**Additional context**
Depends on nasa/cfe#2474

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
