### PR TITLE
Fix #181, correct off-by-one error in CI_LAB_ReadUpLink

### DIFF
--- a/fsw/src/ci_lab_app.c
+++ b/fsw/src/ci_lab_app.c
@@ -218,7 +218,7 @@ void CI_LAB_ReadUpLink(void)
     CFE_Status_t     CfeStatus;
     CFE_SB_Buffer_t *SBBufPtr;
 
-    for (i = 0; i <= CI_LAB_MAX_INGEST_PKTS; i++)
+    for (i = 0; i < CI_LAB_MAX_INGEST_PKTS; i++)
     {
         if (CI_LAB_Global.NetBufPtr == NULL)
         {

--- a/fsw/src/ci_lab_app.h
+++ b/fsw/src/ci_lab_app.h
@@ -81,16 +81,6 @@ void CI_LAB_ReadUpLink(void);
 /* Global State Object */
 extern CI_LAB_GlobalData_t CI_LAB_Global;
 
-/*
- * Individual message handler function prototypes
- *
- * Per the recommended code pattern, these should accept a const pointer
- * to a structure type which matches the message, and return an int32
- * where CFE_SUCCESS (0) indicates successful handling of the message.
- */
-int32 CI_LAB_Noop(const CI_LAB_NoopCmd_t *data);
-int32 CI_LAB_ResetCounters(const CI_LAB_ResetCountersCmd_t *data);
-
 /* Housekeeping message handler */
 int32 CI_LAB_ReportHousekeeping(const CFE_MSG_CommandHeader_t *data);
 

--- a/fsw/src/ci_lab_eds_dispatch.c
+++ b/fsw/src/ci_lab_eds_dispatch.c
@@ -76,8 +76,6 @@ void CI_LAB_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
     CFE_SB_MsgId_t MsgId;
     CFE_Status_t   Status;
 
-    CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MsgId);
-
     Status = EdsDispatch_CI_LAB_Application_Telecommand(SBBufPtr, &CI_LAB_TC_DISPATCH_TABLE);
 
     if (Status != CFE_SUCCESS)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #181 
  - Updates the for loop condition in `CI_LAB_ReadUpLink()` to run as many times as expected.

Couple minor fixes piggy-backing on this PR:
- remove duplicate call to `CFE_MSG_GetMsgId()` in `CI_LAB_TaskPipe()` - probably a copy-paste leftover from a previous refactor
- remove unused declarations `CI_LAB_Noop()` and `CI_LAB_ResetCounters()` - also leftovers from a previous refactor


**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt