### PR TITLE
Fix #197, Initialize Variable msg_size in ci_lab_passthru_decode.c

### DIFF
--- a/fsw/src/ci_lab_passthru_decode.c
+++ b/fsw/src/ci_lab_passthru_decode.c
@@ -92,11 +92,12 @@ CFE_Status_t CI_LAB_DecodeInputMessage(void *SourceBuffer, size_t SourceSize, CF
     else
     {
         MsgBufPtr = SourceBuffer;
+        MsgSize   = 0;
 
         /* Check the size from within the header itself, compare against network buffer size */
-        CFE_MSG_GetSize(&MsgBufPtr->Msg, &MsgSize);
+        Status = CFE_MSG_GetSize(&MsgBufPtr->Msg, &MsgSize);
 
-        if (MsgSize > SourceSize)
+        if ((Status == CFE_SUCCESS) && (MsgSize > SourceSize))
         {
             Status = CFE_STATUS_WRONG_MSG_LENGTH;
 
@@ -105,10 +106,6 @@ CFE_Status_t CI_LAB_DecodeInputMessage(void *SourceBuffer, size_t SourceSize, CF
                               "CI: cmd dropped - length mismatch, %lu (hdr) / %lu (packet)\n",
                               (unsigned long)MsgSize,
                               (unsigned long)SourceSize);
-        }
-        else
-        {
-            Status = CFE_SUCCESS;
         }
     }
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #197 

**Testing performed**
Workflows and reran CodeSonar. CodeSonar analysis link provided in the internal GitHub issue.

**Expected behavior changes**
Resolve CodeSonar warning of Uninitialized Variable in ci_lab_passthru_decode.c

**System(s) tested on**
GitHub Actions and CodeSonar

**Additional context**
Adds Missing Parentheses warning for 
```
if (Status != CFE_SUCCESS || MsgSize > SourceSize)
```
This can be suppressed on CodeSonar or updated. This style can be found in other apps.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.