### PR TITLE
Part nasa/cFS#1079, Adding specialty PR templates and links to the specialty PR templates in the default PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
@@ -1,0 +1,50 @@
+---
+name: Comment / Documentation Change
+about: Changes limited to comments, README, docstrings, or other documentation
+labels: documentation
+---
+
+## Description of Change
+
+<!-- Briefly describe what documentation/comments were changed and why. -->
+
+## Linked Issue
+
+<!-- Required. Reference the GitHub issue this PR addresses, e.g., Closes #123 -->
+Closes #
+
+## Areas of Expertise Touched
+
+<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above/linked to this PR
+- [ ] Documentation generation workflow ran successfully on this branch
+- [ ] Changes are limited to documentation/comments (no code behavior changes)
+
+---
+
+## Reviewer Checklist
+
+- [ ] Documentation is clear, accurate, and complete
+- [ ] Spelling and grammar reviewed
+- [ ] Any links in the documentation have been verified to work
+- [ ] Documentation generation workflow output looks correct
+- [ ] Appropriate Expert areas have been reviewed

--- a/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
@@ -16,6 +16,7 @@ Closes #
 ## Areas of Expertise Touched
 
 <!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
 - [ ] ASTRO
 - [ ] CI/CD
 - [ ] COSMOS

--- a/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
@@ -1,0 +1,88 @@
+---
+name: FSW Code Change
+about: Flight Software code changes
+labels: fsw
+---
+
+## Description of Change
+
+<!-- Describe what was changed, why, and how. Include any design notes that will help reviewers. -->
+
+## Linked Issue
+
+Closes #
+
+## Requirements Impact
+
+<!-- List any requirements impacted by this change. Indicate whether each was updated, or confirm the change continues to satisfy existing requirements. -->
+- Requirement ID(s):
+- [ ] Requirements updated as necessary
+- [ ] Existing requirements are still satisfied by this change
+
+## Testing Evidence
+
+<!-- Paste relevant test output, link to CI runs, or attach screenshots. -->
+
+### Unit Tests (UT Assert)
+<!-- Link to CI run or paste summary -->
+
+### COSMOS Test Suite
+<!-- Link to CI run, paste summary, or note "N/A — no relevant changes" -->
+
+## Areas of Expertise Touched
+
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above
+- [ ] Code has been formatted with `.clang-format`
+- [ ] Static analysis workflows ran and passed
+- [ ] Unit tests (UT Assert) updated/added to cover code changes
+- [ ] Unit test workflows ran and passed
+- [ ] COSMOS test suite was run; tests updated/added if relevant changes were made
+- [ ] Requirements have been reviewed; updated or confirmed still satisfied (see above)
+- [ ] Testing evidence is included above
+- [ ] Self-review of the diff completed
+
+---
+
+## Reviewer Checklist
+
+- [ ] Code logic is correct and matches the stated intent
+- [ ] Code is readable, maintainable, and follows project conventions
+- [ ] `.clang-format` has been applied
+- [ ] Static analysis results reviewed and acceptable
+- [ ] Unit tests are meaningful and adequately cover the changes
+- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
+- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
+- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
+- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
+- [ ] Requirements impact reviewed and appropriate
+- [ ] Error handling is appropriate
+- [ ] Appropriate Expert areas have been reviewed
+
+### Reviewer Testing Notes
+
+<!--
+Describe how you independently verified this change. For example:
+  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
+  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
+  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
+  - "Performed ad-hoc test by [describe scenario]; observed [result]."
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
@@ -31,6 +31,8 @@ Closes #
 
 ## Areas of Expertise Touched
 
+<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
 - [ ] ASTRO
 - [ ] CI/CD
 - [ ] COSMOS
@@ -65,10 +67,9 @@ Closes #
 ## Reviewer Checklist
 
 - [ ] Code logic is correct and matches the stated intent
-- [ ] Code is readable, maintainable, and follows project conventions
+- [ ] Code is readable, maintainable, and follows project conventions (ask your lead if you are unsure of where to find these conventions)
 - [ ] `.clang-format` has been applied
 - [ ] Static analysis results reviewed and acceptable
-- [ ] Unit tests are meaningful and adequately cover the changes
 - [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
 - [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
 - [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)

--- a/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
@@ -1,0 +1,50 @@
+---
+name: Workflows Change
+about: Changes to files under .github/workflows/
+labels: ci/workflows
+---
+
+## Description of Change
+
+<!-- Describe what workflow(s) were changed and why. -->
+
+## Linked Issue
+
+Closes #
+
+## Areas of Expertise Touched
+
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above
+- [ ] Workflow changes were tested on a branch/fork before submitting this PR
+- [ ] All workflows ran successfully on this branch
+
+---
+
+## Reviewer Checklist
+
+- [ ] Workflow logic is correct and achieves the stated goal
+- [ ] Third-party actions are from trusted sources and pinned to a specific SHA/tag
+- [ ] Secrets are handled appropriately (no secrets exposed in logs, least-privilege usage)
+- [ ] Workflow permissions follow the principle of least privilege
+- [ ] Changes do not break or bypass existing branch protection rules
+- [ ] All workflow runs on this PR completed successfully
+- [ ] Appropriate Expert areas have been reviewed

--- a/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
@@ -14,6 +14,8 @@ Closes #
 
 ## Areas of Expertise Touched
 
+<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
 - [ ] ASTRO
 - [ ] CI/CD
 - [ ] COSMOS

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+**For members of the cFS Team**
+Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
+- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
+- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
+- [Workflows Change](?expand=1&template=workflows_change.md)
+
 **Describe the contribution**
 A clear and concise description of what the contribution is.
 - Include explicitly what issue it addresses [e.g. Fixes #X]
@@ -27,9 +33,4 @@ If included, identify any third party code and provide text file of license
 **Contributor Info - All information REQUIRED for consideration of pull request**
 Full name and company/organization/center of all contributors ("Personal" if individual work)
  - Note CLA's apply to software contributions.
-
-**For members of the cFS Team**
-Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
-- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
-- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
-- [Workflows Change](?expand=1&template=workflows_change.md)
+ 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,10 @@ If included, identify any third party code and provide text file of license
 
 **Contributor Info - All information REQUIRED for consideration of pull request**
 Full name and company/organization/center of all contributors ("Personal" if individual work)
-- If NASA Civil Servant Employee or GSFC Contractor on SES II
-  - Address/email/phone and contract/task information (if applicable) must be on file
-  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Corp_CLA_form_1219.pdf)
-- Else if Individual
-  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Ind_CLA_form_1219.pdf)
+ - Note CLA's apply to software contributions.
+
+**For members of the cFS Team**
+Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
+- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
+- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
+- [Workflows Change](?expand=1&template=workflows_change.md)


### PR DESCRIPTION
## Description of Change

Adding specialty PR templates to this repository and adding links to these templates in the default PR template.

## Linked Issue

<!-- Required. Reference the GitHub issue this PR addresses, e.g., Closes #123 -->
Partially Closes nasa/cFS#1079

## Areas of Expertise Touched

<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above/linked to this PR
- [x] Documentation generation workflow ran successfully on this branch
- [x] Changes are limited to documentation/comments (no code behavior changes)

---

## Reviewer Checklist

- [x] Documentation is clear, accurate, and complete
- [x] Spelling and grammar reviewed
- [ ] Any links in the documentation have been verified to work
- [ ] Documentation generation workflow output looks correct
- [x] Appropriate Expert areas have been reviewed